### PR TITLE
chore: Mocket should implement Socket

### DIFF
--- a/reps/test/util/test-utils.ts
+++ b/reps/test/util/test-utils.ts
@@ -43,7 +43,7 @@ export function clientMutation(
   };
 }
 
-export class Mocket implements Socket {
+export class Mocket extends EventTarget implements Socket {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   accept(): void {}
   log: string[][] = [];


### PR DESCRIPTION
This was easiest done by extending EventTarget.