### PR TITLE
Simplify scheduling of running mutations.

### DIFF
--- a/reps/src/process/process-frame.ts
+++ b/reps/src/process/process-frame.ts
@@ -24,17 +24,9 @@ export async function processFrame(
   mutators: MutatorMap,
   clients: ClientID[],
   storage: Storage,
-  startTime: number,
-  endTime: number
+  timestamp: number
 ): Promise<ClientPokeBody[]> {
-  lc.debug?.(
-    "processing frame - startTime",
-    startTime,
-    "endTime",
-    endTime,
-    "clients",
-    clients
-  );
+  lc.debug?.("processing frame - clients", clients);
 
   const cache = new EntryCache(storage);
   const prevVersion = must(await getVersion(cache));
@@ -44,11 +36,6 @@ export async function processFrame(
 
   for (; !mutations.peek().done; mutations.next()) {
     const { value: mutation } = mutations.peek();
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    if (mutation!.timestamp >= endTime) {
-      lc.debug?.("reached end of frame", mutation);
-      break;
-    }
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await processMutation(lc, mutation!, mutators, cache, nextVersion);
   }
@@ -75,7 +62,7 @@ export async function processFrame(
         cookie: nextVersion,
         lastMutationID: clientRecord.lastMutationID,
         patch,
-        timestamp: startTime,
+        timestamp,
       },
     };
     ret.push(poke);

--- a/reps/src/process/process-pending.ts
+++ b/reps/src/process/process-pending.ts
@@ -13,8 +13,6 @@ import { processRoom } from "./process-room";
  * Processes all mutations in all rooms for a time range, and send relevant pokes.
  * @param rooms All active rooms
  * @param mutators All known mutators
- * @param startTime Timespan start
- * @param endTime Timespan end
  */
 export async function processPending(
   lc: LogContext,
@@ -23,22 +21,13 @@ export async function processPending(
   clients: ClientMap,
   // All known mutators
   mutators: MutatorMap,
-  // Span of server time to execute
-  startTime: number,
-  endTime: number
+  timestamp: number
 ): Promise<void> {
-  lc.debug?.("process pending - startTime", startTime, "endTime", endTime);
+  lc.debug?.("process pending");
 
   const t0 = Date.now();
   try {
-    const pokes = await processRoom(
-      lc,
-      clients,
-      mutators,
-      startTime,
-      endTime,
-      durable
-    );
+    const pokes = await processRoom(lc, clients, mutators, durable, timestamp);
 
     sendPokes(lc, pokes, clients);
     clearPendingMutations(lc, pokes, clients);

--- a/reps/src/server/server.ts
+++ b/reps/src/server/server.ts
@@ -32,21 +32,15 @@ export type ProcessHandler = (
 export class Server {
   private readonly _clients: ClientMap = new Map();
   private readonly _lock = new Lock();
-  private readonly _processHandler: ProcessHandler;
-  private readonly _now: Now;
-  private readonly _setTimeout: SetTimeout;
   private readonly _mutators: MutatorMap;
   private readonly _logLevel: LogLevel;
-  private _processing = false;
+  private _turnTimerID: number | null = null;
 
   constructor(private readonly _state: DurableObjectState) {
     // TODO: inject somehow
     this._mutators = new Map([...Object.entries(mutators)]) as MutatorMap;
     this._logLevel = "debug";
     this._clients = new Map();
-    this._processHandler = processPending;
-    this._now = Date.now.bind(Date);
-    this._setTimeout = setTimeout.bind(globalThis);
   }
 
   async fetch(request: Request) {
@@ -107,41 +101,36 @@ export class Server {
       Math.random().toString(36).substr(2)
     );
     lc.debug?.("handling processUntilDone");
-    if (this._processing) {
+    if (this._turnTimerID !== null) {
       lc.debug?.("already processing, nothing to do");
       return;
     }
-    this._processing = true;
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.processNext(lc);
+    this._turnTimerID = setInterval(() => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      this.processNext(lc);
+    }, 1000 / 60);
   }
 
   async processNext(lc: LogContext) {
-    lc.debug?.("processNext - waiting for lock");
+    lc.debug?.(
+      `processNext - starting turn at ${Date.now()} - waiting for lock`
+    );
     await this._lock.withLock(async () => {
-      lc.debug?.("received lock");
+      lc.debug?.(`received lock at ${Date.now()}`);
 
       if (!hasPendingMutations(this._clients)) {
         lc.debug?.("No pending mutations to process, exiting");
-        this._processing = false;
+        clearInterval(this._turnTimerID!);
+        this._turnTimerID = null;
         return;
       }
 
-      const taskStartTime = this._now();
-      const simEndTime = taskStartTime - SERVER_BUFFER_MS;
-      const simStartTime = simEndTime - PROCESS_INTERVAL_MS;
-      await this._processHandler(
+      await processPending(
         lc,
         this._state.storage,
         this._clients,
-        this._mutators,
-        simStartTime,
-        simEndTime
+        this._mutators
       );
-      const elapsed = this._now() - taskStartTime;
-      const delay = Math.max(0, PROCESS_INTERVAL_MS - elapsed);
-      lc.debug?.("scheduling processNext in", delay, "ms");
-      this._setTimeout(() => this.processNext(lc), delay);
     });
   }
 

--- a/reps/test/process/process-frame.test.ts
+++ b/reps/test/process/process-frame.test.ts
@@ -23,7 +23,6 @@ test("processFrame", async () => {
     [clientRecordKey("c2"), clientRecord(1, 7)],
   ]);
   const startTime = 100;
-  const endTime = 200;
   const startVersion = 1;
   const endVersion = 2;
 
@@ -182,41 +181,6 @@ test("processFrame", async () => {
       ]),
       expectedVersion: endVersion,
     },
-    {
-      name: "frame cutoff",
-      mutations: [
-        clientMutation("c1", 2, "put", { key: "foo", value: "bar" }, 50),
-        clientMutation("c1", 3, "put", { key: "foo", value: "baz" }, 150),
-        clientMutation("c1", 4, "put", { key: "foo", value: "bonk" }, 250),
-      ],
-      clients: ["c1"],
-      expectedPokes: [
-        {
-          clientID: "c1",
-          poke: {
-            baseCookie: startVersion,
-            cookie: endVersion,
-            lastMutationID: 3,
-            patch: [
-              {
-                op: "put",
-                key: "foo",
-                value: "baz",
-              },
-            ],
-            timestamp: startTime,
-          },
-        },
-      ],
-      expectedUserValues: new Map([
-        [userValueKey("foo"), userValue("baz", endVersion)],
-      ]),
-      expectedClientRecords: new Map([
-        ...records,
-        [clientRecordKey("c1"), clientRecord(endVersion, 3)],
-      ]),
-      expectedVersion: endVersion,
-    },
   ];
 
   const durable = await getMiniflareDurableObjectStorage(id);
@@ -235,8 +199,7 @@ test("processFrame", async () => {
       mutators,
       c.clients,
       storage,
-      startTime,
-      endTime
+      startTime
     );
 
     expect(result).toEqual(c.expectedPokes);


### PR DESCRIPTION
This just runs mutations as fast as they come in 🤷‍♂️ and rips out all the complex timing stuff. The goal is to see how fast it can go and sort of verify that what we are seeing is likely logical bugs / maybe bad APIs and not perf limitations, as we as to create a well performing baseline to build on top of.

Fixes #1