### PR TITLE
feat!: Inject mutators as argument to Server

### DIFF
--- a/reps/src/index.ts
+++ b/reps/src/index.ts
@@ -1,3 +1,6 @@
+import { Server as BaseServer } from "./server/server";
+import { mutators, type M } from "../../datamodel/mutators";
+
 export async function handleRequest(request: Request, env: Bindings) {
   // Match route against pattern /:name/*action
   const url = new URL(request.url);
@@ -24,5 +27,10 @@ export async function handleRequest(request: Request, env: Bindings) {
 
 const worker: ExportedHandler<Bindings> = { fetch: handleRequest };
 
-export { Server } from "./server/server";
+export class Server extends BaseServer<M> {
+  constructor(state: DurableObjectState) {
+    super(mutators, state);
+  }
+}
+
 export default worker;

--- a/reps/src/server/server.ts
+++ b/reps/src/server/server.ts
@@ -7,8 +7,7 @@ import { LogContext } from "../util/logger";
 import { handleClose } from "./close";
 import { handleConnection } from "./connect";
 import { handleMessage } from "./message";
-import { LogLevel } from "replicache";
-import { mutators } from "../../../datamodel/mutators";
+import { LogLevel, MutatorDefs } from "replicache";
 
 // We aim to process frames 30 times per second.
 const PROCESS_INTERVAL_MS = 1000 / 30;
@@ -29,15 +28,14 @@ export type ProcessHandler = (
   endTime: number
 ) => Promise<void>;
 
-export class Server {
+export class Server<MD extends MutatorDefs> {
   private readonly _clients: ClientMap = new Map();
   private readonly _lock = new Lock();
   private readonly _mutators: MutatorMap;
   private readonly _logLevel: LogLevel;
   private _turnTimerID: number | null = null;
 
-  constructor(private readonly _state: DurableObjectState) {
-    // TODO: inject somehow
+  constructor(mutators: MD, private readonly _state: DurableObjectState) {
     this._mutators = new Map([...Object.entries(mutators)]) as MutatorMap;
     // TODO: make configurable
     this._logLevel = "debug";


### PR DESCRIPTION
The `Server` class now takes the `mutators` as an argument. Since
CloudFlare workers instantiate a class with `state` and `env` and no
other parameters, we have to get the mutators in there in some other
way.

This PR proposes to do it using inheritance.

Towards #3