### PR TITLE
chore: Upgrade replidraw-do to reflect@0.5.0 and reflect-server@0.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@cloudflare/workers-types": "^3.3.1",
-        "@rocicorp/reflect": "^0.4.0",
-        "@rocicorp/reflect-server": "^0.10.0",
+        "@rocicorp/reflect": "^0.5.0",
+        "@rocicorp/reflect-server": "^0.11.0",
         "@types/node": "^17.0.16",
         "@types/react": "^17.0.39",
         "@types/react-dom": "^17.0.11",
@@ -448,16 +448,16 @@
       }
     },
     "node_modules/@rocicorp/reflect": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@rocicorp/reflect/-/reflect-0.4.0.tgz",
-      "integrity": "sha512-PaCL1O0Aigzl7DCcOi1gF7XcdiatVco97MRFrI9qrSLma+seJ1Cu2fIncZtbdgzJ1EDGpkZdP4tVQe5I9zPhaw=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@rocicorp/reflect/-/reflect-0.5.0.tgz",
+      "integrity": "sha512-7pJ8EUvQ0YxtznZNRh84cFGHwnDPwoAU8luP0z2kVyQlgWPFiA6VX6vwIdFm9M3CslvYb6AAbLIFk9c4pF0BNA=="
     },
     "node_modules/@rocicorp/reflect-server": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@rocicorp/reflect-server/-/reflect-server-0.10.0.tgz",
-      "integrity": "sha512-3ggaKq3kbNW/LVb3zwxDRjhSjst+hN1iDglMBst/1FvwGkloLpYwLu23hBSd0E+Uv5SIusi6l/ekS6/HL69CZA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@rocicorp/reflect-server/-/reflect-server-0.11.0.tgz",
+      "integrity": "sha512-xJxfkuhb10dI26HBSUKhQK7EI13W2mJNMe1tfUV8YFLqQZa+tbLNGHn3eqIpZMHAEXZkg0gkHOPSfadTzCGpKw==",
       "engines": {
-        "node": ">=16.14.0 <16.14.1 || >=17.1 <17.5"
+        "node": ">=16.14.0 || >=17.1"
       }
     },
     "node_modules/@types/invariant": {
@@ -1791,14 +1791,14 @@
       }
     },
     "@rocicorp/reflect": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@rocicorp/reflect/-/reflect-0.4.0.tgz",
-      "integrity": "sha512-PaCL1O0Aigzl7DCcOi1gF7XcdiatVco97MRFrI9qrSLma+seJ1Cu2fIncZtbdgzJ1EDGpkZdP4tVQe5I9zPhaw=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@rocicorp/reflect/-/reflect-0.5.0.tgz",
+      "integrity": "sha512-7pJ8EUvQ0YxtznZNRh84cFGHwnDPwoAU8luP0z2kVyQlgWPFiA6VX6vwIdFm9M3CslvYb6AAbLIFk9c4pF0BNA=="
     },
     "@rocicorp/reflect-server": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@rocicorp/reflect-server/-/reflect-server-0.10.0.tgz",
-      "integrity": "sha512-3ggaKq3kbNW/LVb3zwxDRjhSjst+hN1iDglMBst/1FvwGkloLpYwLu23hBSd0E+Uv5SIusi6l/ekS6/HL69CZA=="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@rocicorp/reflect-server/-/reflect-server-0.11.0.tgz",
+      "integrity": "sha512-xJxfkuhb10dI26HBSUKhQK7EI13W2mJNMe1tfUV8YFLqQZa+tbLNGHn3eqIpZMHAEXZkg0gkHOPSfadTzCGpKw=="
     },
     "@types/invariant": {
       "version": "2.2.35",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@cloudflare/workers-types": "^3.3.1",
-    "@rocicorp/reflect": "^0.4.0",
-    "@rocicorp/reflect-server": "^0.10.0",
+    "@rocicorp/reflect": "^0.5.0",
+    "@rocicorp/reflect-server": "^0.11.0",
     "@types/node": "^17.0.16",
     "@types/react": "^17.0.39",
     "@types/react-dom": "^17.0.11",

--- a/src/datamodel/client-state.ts
+++ b/src/datamodel/client-state.ts
@@ -100,27 +100,44 @@ export async function setCursor(
   { id, x, y }: { id: string; x: number; y: number }
 ): Promise<void> {
   const clientState = await getClientState(tx, id);
-  clientState.cursor.x = x;
-  clientState.cursor.y = y;
-  await putClientState(tx, { id, clientState });
+  await putClientState(tx, {
+    id,
+    clientState: {
+      ...clientState,
+      cursor: {
+        x,
+        y,
+      },
+    },
+  });
 }
 
 export async function overShape(
   tx: WriteTransaction,
   { clientID, shapeID }: { clientID: string; shapeID: string }
 ): Promise<void> {
-  const client = await getClientState(tx, clientID);
-  client.overID = shapeID;
-  await putClientState(tx, { id: clientID, clientState: client });
+  const clientState = await getClientState(tx, clientID);
+  await putClientState(tx, {
+    id: clientID,
+    clientState: {
+      ...clientState,
+      overID: shapeID,
+    },
+  });
 }
 
 export async function selectShape(
   tx: WriteTransaction,
   { clientID, shapeID }: { clientID: string; shapeID: string }
 ): Promise<void> {
-  const client = await getClientState(tx, clientID);
-  client.selectedID = shapeID;
-  await putClientState(tx, { id: clientID, clientState: client });
+  const clientState = await getClientState(tx, clientID);
+  await putClientState(tx, {
+    id: clientID,
+    clientState: {
+      ...clientState,
+      selectedID: shapeID,
+    },
+  });
 }
 
 export function randUserInfo(): UserInfo {

--- a/src/datamodel/shape.ts
+++ b/src/datamodel/shape.ts
@@ -48,9 +48,14 @@ export async function moveShape(
 ): Promise<void> {
   const shape = await getShape(tx, id);
   if (shape) {
-    shape.x += dx;
-    shape.y += dy;
-    await putShape(tx, { id, shape });
+    await putShape(tx, {
+      id,
+      shape: {
+        ...shape,
+        x: shape.x + dx,
+        y: shape.y + dy,
+      },
+    });
   }
 }
 
@@ -62,11 +67,17 @@ export async function scanShape(
   if (!shape) {
     return;
   }
-  shape.x += dx;
-  if (shape.x > maxX) {
-    shape.x = 0;
+  let newX = (shape.x += dx);
+  if (newX > maxX) {
+    newX = 0;
   }
-  putShape(tx, { id, shape });
+  putShape(tx, {
+    id,
+    shape: {
+      ...shape,
+      x: newX,
+    },
+  });
 }
 
 export async function resizeShape(
@@ -78,11 +89,16 @@ export async function resizeShape(
     const minSize = 10;
     const dw = Math.max(minSize - shape.width, ds);
     const dh = Math.max(minSize - shape.height, ds);
-    shape.width += dw;
-    shape.height += dh;
-    shape.x -= dw / 2;
-    shape.y -= dh / 2;
-    await putShape(tx, { id, shape });
+    await putShape(tx, {
+      id,
+      shape: {
+        ...shape,
+        width: shape.width + dw,
+        height: shape.height + dh,
+        x: shape.x - dw / 2,
+        y: shape.y - dh / 2,
+      },
+    });
   }
 }
 
@@ -92,8 +108,13 @@ export async function rotateShape(
 ): Promise<void> {
   const shape = await getShape(tx, id);
   if (shape) {
-    shape.rotate += ddeg;
-    await putShape(tx, { id, shape });
+    await putShape(tx, {
+      id,
+      shape: {
+        ...shape,
+        rotate: shape.rotate + ddeg,
+      },
+    });
   }
 }
 


### PR DESCRIPTION
As part of this upgrade I had to fix the mutators to not directly modify the objects returned from reflect.  This was a bug in the existing replidraw-do code revealed by this upgrade.

Fixes [reflect-server rocicorp/mono#295](https://github.com/rocicorp/mono/issues/295)