### PR TITLE
feat: Update to wrangler v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Running live at [replidraw-do.vercel.app](https://replidraw-do.vercel.app/).
 
 ## Hacking Locally
 
-The `dev-worker` command runs the worker using [Miniflare](https://miniflare.dev/), a really nice Cloudflare emulation environment. This is super convenient and doesn't require a CF account. Unfortunately, it also doesn't give you a realistic view of performance since everything is local.
+The `dev-worker` command runs the worker using [wrangler](https://developers.cloudflare.com/workers/wrangler/) in local mode, a really nice Cloudflare emulation environment. This is super convenient and doesn't require a CF account. Unfortunately, it also doesn't give you a realistic view of performance since everything is local.
 
 ```bash
 npm install
@@ -24,9 +24,7 @@ NEXT_PUBLIC_WORKER_HOST=ws://localhost:8787 npm run dev
 ## Publishing Worker to Cloudflare
 
 1. Get an account at Cloudflare: https://workers.cloudflare.com/.
-2. Install the [Wrangler v1 CLI tool](https://developers.cloudflare.com/workers/wrangler/cli-wrangler/install-update/) 
-
-**Important:** these instructions only work with v1 of the wrangler CLI. TODO: Figure out v2.
+2. Install the [Wrangler CLI tool](https://developers.cloudflare.com/workers/wrangler/get-started/)
 
 Then:
 
@@ -40,7 +38,7 @@ npm run dev
 
 ## Developing against Cloudflare
 
-It is possible to develop using the Cloudflare network without destabilizing the production copy of a worker. This provides a more realistic idea of latency than Miniflare.
+It is possible to develop using the Cloudflare network without destabilizing the production copy of a worker. This provides a more realistic idea of latency than Wrangler.
 
 ```
 # Must have published at least once prior

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "replidraw-do",
       "version": "0.1.0",
       "dependencies": {
-        "@cloudflare/workers-types": "^3.3.1",
+        "@cloudflare/workers-types": "^3.11.0",
         "@datadog/browser-logs": "^4.11.3",
         "@rocicorp/logger": "^2.2.0",
         "@rocicorp/reflect": "^0.6.0",
@@ -17,8 +17,6 @@
         "@types/react": "^17.0.39",
         "@types/react-dom": "^17.0.11",
         "bootstrap": "^4.6.0",
-        "esbuild": "^0.14.20",
-        "miniflare": "^2.3.0",
         "nanoid": "^3.2.0",
         "next": "^12.1.6",
         "prettier": "^2.5.1",
@@ -29,6 +27,7 @@
         "react-hotkeys": "^1.1.4",
         "replicache-react": "^2.6.0",
         "typescript": "^4.5.5",
+        "wrangler": "^2.0.7",
         "zod": "^3.11.6"
       }
     },
@@ -43,10 +42,18 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.2.0.tgz",
+      "integrity": "sha512-MVbXLbTcAotOPUj0pAMhVtJ+3/kFkwJqc5qNOleOZTv6QkZZABDMS21dSrSlVswEHwrpWC03e4fWytjqKvuE2A==",
+      "dependencies": {
+        "mime": "^3.0.0"
+      }
+    },
     "node_modules/@cloudflare/workers-types": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.3.1.tgz",
-      "integrity": "sha512-GJFDgWd8ZHlr/m+Q2mp4xUl0/FIPpR6kf0Ix2C78E9HeJyUCW0c0w2EKCvgEDFFKB2rkzIX3eBqZCnLsbsw8zQ=="
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.14.1.tgz",
+      "integrity": "sha512-B1/plF62pt+H2IJHvApK8fdOJAVsvojvacuac8x8s+JIyqbropMyqNqHTKLm3YD8ZFLGwYeFTudU+PQ7vGvBdA=="
     },
     "node_modules/@datadog/browser-core": {
       "version": "4.11.3",
@@ -61,31 +68,51 @@
         "@datadog/browser-core": "4.11.3"
       }
     },
+    "node_modules/@esbuild-plugins/node-globals-polyfill": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.1.1.tgz",
+      "integrity": "sha512-MR0oAA+mlnJWrt1RQVQ+4VYuRJW/P2YmRTv1AsplObyvuBMnPHiizUF95HHYiSsMGLhyGtWufaq2XQg6+iurBg==",
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-modules-polyfill": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.1.4.tgz",
+      "integrity": "sha512-uZbcXi0zbmKC/050p3gJnne5Qdzw8vkXIv+c2BW0Lsc1ji1SkrxbKPUy5Efr0blbTu1SL8w4eyfpnSdPg3G0Qg==",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "rollup-plugin-node-polyfills": "^0.2.1"
+      },
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
     "node_modules/@iarna/toml": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
     },
     "node_modules/@miniflare/cache": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.4.0.tgz",
-      "integrity": "sha512-tMDXlUVlThgFubJmlxZoKmLK8kBxDmuMbVMt7csHpXegzkuo2TmIsDqBE/C3CRiJ5xeCQgpD6iZtKBu5Zn5fRA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.6.0.tgz",
+      "integrity": "sha512-4oh8MgpquoxaslI7Z8sMzmEZR0Dc+L3aEh69o9d8ZCs4nUdOENnfKlY50O5nEnL7nhhyAljkMBaXD2wAH2DLeQ==",
       "dependencies": {
-        "@miniflare/core": "2.4.0",
-        "@miniflare/shared": "2.4.0",
+        "@miniflare/core": "2.6.0",
+        "@miniflare/shared": "2.6.0",
         "http-cache-semantics": "^4.1.0",
-        "undici": "4.13.0"
+        "undici": "5.5.1"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/cli-parser": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.4.0.tgz",
-      "integrity": "sha512-Xr5lO8f+oIr9r/b2dfo0on1p0MNN+pkwRHWoY5ACSnp9FaGnwm/g71DM7AajIQPIk0TpRsSVNDx8Ygj1LPT+sQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.6.0.tgz",
+      "integrity": "sha512-dJDoIPAUqWhzvBHHyqyhobdzDedBYRWZ4yItBi9m4MTU/EneLJ5jryB340SwUnmtBMZxUh/LWdAuUEkKpdVNyA==",
       "dependencies": {
-        "@miniflare/shared": "2.4.0",
+        "@miniflare/shared": "2.6.0",
         "kleur": "^4.1.4"
       },
       "engines": {
@@ -93,62 +120,63 @@
       }
     },
     "node_modules/@miniflare/core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.4.0.tgz",
-      "integrity": "sha512-vYl8xaWTFzxtkbzx3IkT4Py0OAFdfmFnVo627O1HKHWVGlkjVr8UKtxBpIR+f5pq/HCMzzqA1HM9FXO0dQfy3A==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.6.0.tgz",
+      "integrity": "sha512-CmofhIRot++GI7NHPMwzNb65+0hWLN186L91BrH/doPVHnT/itmEfzYQpL9bFLD0c/i14dfv+IUNetDdGEBIrw==",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/watcher": "2.4.0",
-        "busboy": "^0.3.1",
+        "@miniflare/shared": "2.6.0",
+        "@miniflare/watcher": "2.6.0",
+        "busboy": "^1.6.0",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "4.13.0"
+        "undici": "5.5.1",
+        "urlpattern-polyfill": "^4.0.3"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/durable-objects": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.4.0.tgz",
-      "integrity": "sha512-VVLaUXXcAQcYE/3YmDLTacZf5OzR8bib6q1T9NqVb0uK5sLMQqyHvQdsG5rMqs7iyxfJxyZ0bL2OW9XGALOkoQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.6.0.tgz",
+      "integrity": "sha512-uzWoGFtkIIh3m3HAzqd5f86nOSC0xFli6dq2q7ilE3UjgouOcLqObxJyE/IzvSwsj4DUWFv6//YDfHihK2fGAA==",
       "dependencies": {
-        "@miniflare/core": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/storage-memory": "2.4.0",
-        "undici": "4.13.0"
+        "@miniflare/core": "2.6.0",
+        "@miniflare/shared": "2.6.0",
+        "@miniflare/storage-memory": "2.6.0",
+        "undici": "5.5.1"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/html-rewriter": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.4.0.tgz",
-      "integrity": "sha512-ZG8819N7LelDD+8+Ss5FZpVyQQq/V2igod0qE68JK4he/w4/yn57Rk6Efb49y15HoHAXl2RpCCsnCyIow/Xjug==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.6.0.tgz",
+      "integrity": "sha512-+JqFlIDLzstb/Spj+j/kI6uHzolrqjsMks3Tf24Q4YFo9YYdZguqUFcDz2yr79ZTP/SKXaZH+AYqosnJps4dHQ==",
       "dependencies": {
-        "@miniflare/core": "2.4.0",
-        "@miniflare/shared": "2.4.0",
+        "@miniflare/core": "2.6.0",
+        "@miniflare/shared": "2.6.0",
         "html-rewriter-wasm": "^0.4.1",
-        "undici": "4.13.0"
+        "undici": "5.5.1"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/http-server": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.4.0.tgz",
-      "integrity": "sha512-r6Z/nqxE0oa1z63L95yvnG0PUeLRxZOeGS7ADxZMFKan4WD5lvYtSKDuDEm0lkbQshCOHQ3uXFr0cotOm8JoMQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.6.0.tgz",
+      "integrity": "sha512-FhcAVIpipMEzMCsJBc/b0JhNEJ66GPX60vA2NcqjGKHYbwoPCPlwCFQq2giPzW/R95ugrEjPfo4/5Q4UbnpoGA==",
       "dependencies": {
-        "@miniflare/core": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/web-sockets": "2.4.0",
+        "@miniflare/core": "2.6.0",
+        "@miniflare/shared": "2.6.0",
+        "@miniflare/web-sockets": "2.6.0",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
-        "undici": "4.13.0",
+        "undici": "5.5.1",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       },
@@ -157,34 +185,46 @@
       }
     },
     "node_modules/@miniflare/kv": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.4.0.tgz",
-      "integrity": "sha512-1UW7f1386xR6EDEXNZOR1TpFwQfRRSxUPqD6m/U0WprlsbM0cIYGz+AUeaVbkFf8lfE2MeXCUrjbWsLOvsnw3g==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.6.0.tgz",
+      "integrity": "sha512-7Q+Q0Wwinsz85qpKLlBeXSCLweiVowpMJ5AmQpmELnTya59HQ24cOUHxPd64hXFhdYXVIxOmk6lQaZ21JhdHGQ==",
       "dependencies": {
-        "@miniflare/shared": "2.4.0"
+        "@miniflare/shared": "2.6.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "node_modules/@miniflare/r2": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.6.0.tgz",
+      "integrity": "sha512-Ymbqu17ajtuk9b11txF2h1Ewqqlu3XCCpAwAgCQa6AK1yRidQECCPq9w9oXZxE1p5aaSuLTOUbgSdtveFCsLxQ==",
+      "dependencies": {
+        "@miniflare/shared": "2.6.0",
+        "undici": "5.5.1"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/runner-vm": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.4.0.tgz",
-      "integrity": "sha512-7sdwBYzXQTwYeR3tTvQ+vJfzc7BXwqR8AUPK9l5gvCtg+Geq9sMslr5SikIJpgcvbYqKDjvC9DQEPJ3sqr9cSQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.6.0.tgz",
+      "integrity": "sha512-ZxsiVMMUcjb01LwrO2t50YbU5PT5s3k7DrmR5185R/n04K5BikqZz8eQf8lKlQQYem0BROqmmQgurZGw0a2HUw==",
       "dependencies": {
-        "@miniflare/shared": "2.4.0"
+        "@miniflare/shared": "2.6.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/scheduler": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.4.0.tgz",
-      "integrity": "sha512-dfMCXoAS8Y+3xABNxYju62I2xIBS54Op7ohCHoatvAM5RvualJUPICEMPZzX6/z29q5xPIeSLhLDhl/asAQ19w==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.6.0.tgz",
+      "integrity": "sha512-BM+RDF+8twkTCOb7Oz0NIs5phzAVJ/Gx7tFZR23fGsZjWRnE3TBeqfzaNutU9pcoWDZtBQqEJMeTeb0KZTo75Q==",
       "dependencies": {
-        "@miniflare/core": "2.4.0",
-        "@miniflare/shared": "2.4.0",
+        "@miniflare/core": "2.6.0",
+        "@miniflare/shared": "2.6.0",
         "cron-schedule": "^3.0.4"
       },
       "engines": {
@@ -192,9 +232,9 @@
       }
     },
     "node_modules/@miniflare/shared": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.4.0.tgz",
-      "integrity": "sha512-lPQFzBUVGNQ93gQ/dliToWnO0OqAgsD3/902Pd/IixVSRwRj3BTnYv2dHMUKZcODBPrhnbqZeqcPWdBLzEx8uw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.6.0.tgz",
+      "integrity": "sha512-/7k4C37GF0INu99LNFmFhHYL6U9/oRY/nWDa5sr6+lPEKKm2rkmfvDIA+YNAj7Ql61ZWMgEMj0S3NhV0rWkj7Q==",
       "dependencies": {
         "ignore": "^5.1.8",
         "kleur": "^4.1.4"
@@ -204,60 +244,60 @@
       }
     },
     "node_modules/@miniflare/sites": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.4.0.tgz",
-      "integrity": "sha512-YZy/TujnR1lkBvCncDDQ8tsWsXRE4JJ4x9a0bKN/XnZh7r6OhDM0sw4BFcBQhT6Ukdtttam1O3FlJxnMitrDGg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.6.0.tgz",
+      "integrity": "sha512-XfWhpREC638LOGNmuHaPn1MAz1sh2mz+VdMsjRCzUo6NwPl4IcUhnorJR62Xr0qmI/RqVMTZbvzrChXio4Bi4A==",
       "dependencies": {
-        "@miniflare/kv": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/storage-file": "2.4.0"
+        "@miniflare/kv": "2.6.0",
+        "@miniflare/shared": "2.6.0",
+        "@miniflare/storage-file": "2.6.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/storage-file": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.4.0.tgz",
-      "integrity": "sha512-f1AUMz8xps/4VhNJMb8JeCevZFeU4pg2lIWmC11gG4xeq2nibTPBi6Qtx594Le7ZKij/tF6rRsoNfGau2Q5gdw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.6.0.tgz",
+      "integrity": "sha512-xprDVJClQ2X1vXVPM16WQZz3rS+6fNuCYC8bfEFHABDByQoUNDpk8q+m1IpTaFXYivYxRhE+xr7eK2QQP068tA==",
       "dependencies": {
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/storage-memory": "2.4.0"
+        "@miniflare/shared": "2.6.0",
+        "@miniflare/storage-memory": "2.6.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/storage-memory": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.4.0.tgz",
-      "integrity": "sha512-mhWwgHhDNtEa7y1bYbdVucV0lqUmzagYXUSppAdSGS5JPyJMyw3HseqRNTk6gC/vKlvEYlFf3ugWcREGCedr9A==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.6.0.tgz",
+      "integrity": "sha512-0EwELTG2r6IC4AMlQv0YXRZdw9g/lCydceuGKeFkWAVb55pY+yMBxkJO9VV7QOrEx8MLsR8tsfl5SBK3AkfLtA==",
       "dependencies": {
-        "@miniflare/shared": "2.4.0"
+        "@miniflare/shared": "2.6.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/watcher": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.4.0.tgz",
-      "integrity": "sha512-gDQRUxwOjmctvowyd4Hcdy3fjxz3ERKzirp6TvA3AWUohKZk3IhwGlaA8aCwbdP+ELYQlG5wK44AfLSGi956fg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.6.0.tgz",
+      "integrity": "sha512-mttfhNDmEIFo2rWF73JeWj1TLN+3cQC1TFhbtLApz9bXilLywArXMYqDJGA8PUnJCFM/8k2FDjaFNiPy6ggIJw==",
       "dependencies": {
-        "@miniflare/shared": "2.4.0"
+        "@miniflare/shared": "2.6.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/web-sockets": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.4.0.tgz",
-      "integrity": "sha512-cz/cN0GoQOXRLh80UmlcEJODPIw2ijKBK3PLRzvfTzqQ5avK6wp2M8Fj8C/5JIT6g7siwvBANyKXD3U3RpKGHQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.6.0.tgz",
+      "integrity": "sha512-ePbcuP9LrStVTllZzqx2oNVoOpceyU3jJF3nGDMNW5+bqB+BdeTggSF8rhER7omcSCswCMY2Do6VelIcAXHkXA==",
       "dependencies": {
-        "@miniflare/core": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "undici": "4.13.0",
+        "@miniflare/core": "2.6.0",
+        "@miniflare/shared": "2.6.0",
+        "undici": "5.5.1",
         "ws": "^8.2.2"
       },
       "engines": {
@@ -555,6 +595,31 @@
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
       "integrity": "sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI="
     },
+    "node_modules/anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="
+    },
     "node_modules/bootstrap": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
@@ -568,26 +633,63 @@
         "popper.js": "^1.16.1"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/busboy": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
-      "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
       "dependencies": {
-        "dicer": "0.3.0"
+        "streamsearch": "^1.1.0"
       },
       "engines": {
-        "node": ">=4.5.0"
+        "node": ">=10.16.0"
       }
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001343",
       "resolved": "https://registry.npmmirror.com/caniuse-lite/-/caniuse-lite-1.0.30001343.tgz",
       "integrity": "sha512-8KeCrAtPMabo/XW14B+R9sZYoClx1n0b+WYgwDKZPtWR3TcdvWzdSy7mPyFEmR5WU1St9v1PW6sdO5dkFOEzfA=="
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
     },
     "node_modules/classnames": {
       "version": "2.3.1",
@@ -628,17 +730,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/dicer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
-      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
-      "dependencies": {
-        "streamsearch": "0.1.2"
-      },
-      "engines": {
-        "node": ">=4.5.0"
-      }
-    },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
@@ -657,9 +748,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.20.tgz",
-      "integrity": "sha512-7aRJRnTjHZ6rFEre52tsAYZxatVELSA/QvYGUBf1iOsYKCnSJICE5seugQFFJgV1Gyl0/mngxQPhxBIqgYG2BA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.51.tgz",
+      "integrity": "sha512-+CvnDitD7Q5sT7F+FM65sWkF8wJRf+j9fPcprxYV4j+ohmzVj2W7caUqH2s5kCaCJAfcAICjSlKhDCcvDpU7nw==",
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -668,30 +759,47 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "esbuild-android-arm64": "0.14.20",
-        "esbuild-darwin-64": "0.14.20",
-        "esbuild-darwin-arm64": "0.14.20",
-        "esbuild-freebsd-64": "0.14.20",
-        "esbuild-freebsd-arm64": "0.14.20",
-        "esbuild-linux-32": "0.14.20",
-        "esbuild-linux-64": "0.14.20",
-        "esbuild-linux-arm": "0.14.20",
-        "esbuild-linux-arm64": "0.14.20",
-        "esbuild-linux-mips64le": "0.14.20",
-        "esbuild-linux-ppc64le": "0.14.20",
-        "esbuild-linux-s390x": "0.14.20",
-        "esbuild-netbsd-64": "0.14.20",
-        "esbuild-openbsd-64": "0.14.20",
-        "esbuild-sunos-64": "0.14.20",
-        "esbuild-windows-32": "0.14.20",
-        "esbuild-windows-64": "0.14.20",
-        "esbuild-windows-arm64": "0.14.20"
+        "esbuild-android-64": "0.14.51",
+        "esbuild-android-arm64": "0.14.51",
+        "esbuild-darwin-64": "0.14.51",
+        "esbuild-darwin-arm64": "0.14.51",
+        "esbuild-freebsd-64": "0.14.51",
+        "esbuild-freebsd-arm64": "0.14.51",
+        "esbuild-linux-32": "0.14.51",
+        "esbuild-linux-64": "0.14.51",
+        "esbuild-linux-arm": "0.14.51",
+        "esbuild-linux-arm64": "0.14.51",
+        "esbuild-linux-mips64le": "0.14.51",
+        "esbuild-linux-ppc64le": "0.14.51",
+        "esbuild-linux-riscv64": "0.14.51",
+        "esbuild-linux-s390x": "0.14.51",
+        "esbuild-netbsd-64": "0.14.51",
+        "esbuild-openbsd-64": "0.14.51",
+        "esbuild-sunos-64": "0.14.51",
+        "esbuild-windows-32": "0.14.51",
+        "esbuild-windows-64": "0.14.51",
+        "esbuild-windows-arm64": "0.14.51"
+      }
+    },
+    "node_modules/esbuild-android-64": {
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.51.tgz",
+      "integrity": "sha512-6FOuKTHnC86dtrKDmdSj2CkcKF8PnqkaIXqvgydqfJmqBazCPdw+relrMlhGjkvVdiiGV70rpdnyFmA65ekBCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/esbuild-android-arm64": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.20.tgz",
-      "integrity": "sha512-MPKVDe3TMjGDRB5WmY9XnBaXEsPiiTpkz6GjXgBhBkMFZm27PhvZT4JE0vZ1fsLb5hnGC/fYsfAnp9rsxTZhIg==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.51.tgz",
+      "integrity": "sha512-vBtp//5VVkZWmYYvHsqBRCMMi1MzKuMIn5XDScmnykMTu9+TD9v0NMEDqQxvtFToeYmojdo5UCV2vzMQWJcJ4A==",
       "cpu": [
         "arm64"
       ],
@@ -704,9 +812,9 @@
       }
     },
     "node_modules/esbuild-darwin-64": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.20.tgz",
-      "integrity": "sha512-09PPWejM3rRFsGHvtaTuRlG+KOQlOMwPW4HwwzRlO4TuP+FNV1nTW4x2Nid3dYLzCkcjznJWQ0oylLBQvGTRyQ==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.51.tgz",
+      "integrity": "sha512-YFmXPIOvuagDcwCejMRtCDjgPfnDu+bNeh5FU2Ryi68ADDVlWEpbtpAbrtf/lvFTWPexbgyKgzppNgsmLPr8PA==",
       "cpu": [
         "x64"
       ],
@@ -719,9 +827,9 @@
       }
     },
     "node_modules/esbuild-darwin-arm64": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.20.tgz",
-      "integrity": "sha512-jYLrSXAwygoFF2lpRJSUAghre+9IThbcPvJQbcZMONBQaaZft9nclNsrN3k4u7zQaC8v+xZDVSHkmw593tQvkg==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.51.tgz",
+      "integrity": "sha512-juYD0QnSKwAMfzwKdIF6YbueXzS6N7y4GXPDeDkApz/1RzlT42mvX9jgNmyOlWKN7YzQAYbcUEJmZJYQGdf2ow==",
       "cpu": [
         "arm64"
       ],
@@ -734,9 +842,9 @@
       }
     },
     "node_modules/esbuild-freebsd-64": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.20.tgz",
-      "integrity": "sha512-XShznPLW3QsK8/7iCx1euZTowWaWlcrlkq4YTlRqDKXkJRe98FJ6+V2QyoSTwwCoo5koaYwc+h/SYdglF5369A==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.51.tgz",
+      "integrity": "sha512-cLEI/aXjb6vo5O2Y8rvVSQ7smgLldwYY5xMxqh/dQGfWO+R1NJOFsiax3IS4Ng300SVp7Gz3czxT6d6qf2cw0g==",
       "cpu": [
         "x64"
       ],
@@ -749,9 +857,9 @@
       }
     },
     "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.20.tgz",
-      "integrity": "sha512-flb3tDd6SScKhBqzWAESVCErpaqrGmMSRrssjx1aC+Ai5ZQrEyhfs5OWL4A9qHuixkhfmXffci7rFD+bNeXmZg==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.51.tgz",
+      "integrity": "sha512-TcWVw/rCL2F+jUgRkgLa3qltd5gzKjIMGhkVybkjk6PJadYInPtgtUBp1/hG+mxyigaT7ib+od1Xb84b+L+1Mg==",
       "cpu": [
         "arm64"
       ],
@@ -764,9 +872,9 @@
       }
     },
     "node_modules/esbuild-linux-32": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.20.tgz",
-      "integrity": "sha512-Avtxbd0MHFJ2QhNxj/e8VGGm1/VnEJZq9qiHUl3wQZ4S0o2Wf4ReAfhqmgAbOPFTuxuZm070rRDZYiZifWzFGQ==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.51.tgz",
+      "integrity": "sha512-RFqpyC5ChyWrjx8Xj2K0EC1aN0A37H6OJfmUXIASEqJoHcntuV3j2Efr9RNmUhMfNE6yEj2VpYuDteZLGDMr0w==",
       "cpu": [
         "ia32"
       ],
@@ -779,9 +887,9 @@
       }
     },
     "node_modules/esbuild-linux-64": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.20.tgz",
-      "integrity": "sha512-ugisoRA/ajCr9JMszsQnT9hKkpbD7Gr1yl1mWdZhWQnGt6JKGIndGiihMURcrR44IK/2OMkixVe66D4gCHKdPA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.51.tgz",
+      "integrity": "sha512-dxjhrqo5i7Rq6DXwz5v+MEHVs9VNFItJmHBe1CxROWNf4miOGoQhqSG8StStbDkQ1Mtobg6ng+4fwByOhoQoeA==",
       "cpu": [
         "x64"
       ],
@@ -794,9 +902,9 @@
       }
     },
     "node_modules/esbuild-linux-arm": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.20.tgz",
-      "integrity": "sha512-uo++Mo31+P2EA38oQgOeSIWgD7GMCMpZkaLfsCqtKJTIIL9fVzQHQYLDRIiFGpLHvs1faWWHDCEcXEFSP1Ou0g==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.51.tgz",
+      "integrity": "sha512-LsJynDxYF6Neg7ZC7748yweCDD+N8ByCv22/7IAZglIEniEkqdF4HCaa49JNDLw1UQGlYuhOB8ZT/MmcSWzcWg==",
       "cpu": [
         "arm"
       ],
@@ -809,9 +917,9 @@
       }
     },
     "node_modules/esbuild-linux-arm64": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.20.tgz",
-      "integrity": "sha512-hsrMbNzhh+ud3zUyhONlR41vpYMjINS7BHEzXHbzo4YiCsG9Ht3arbiSuNGrhR/ybLr+8J/0fYVCipiVeAjy3Q==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.51.tgz",
+      "integrity": "sha512-D9rFxGutoqQX3xJPxqd6o+kvYKeIbM0ifW2y0bgKk5HPgQQOo2k9/2Vpto3ybGYaFPCE5qTGtqQta9PoP6ZEzw==",
       "cpu": [
         "arm64"
       ],
@@ -824,9 +932,9 @@
       }
     },
     "node_modules/esbuild-linux-mips64le": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.20.tgz",
-      "integrity": "sha512-MBUu2Q+pzdTBWclPe7AwmRUMTUL0R99ONa8Hswpb987fXgFUdN4XBNBcEa5zy/l2UrIJK+9FUN1jjedZlxgP2A==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.51.tgz",
+      "integrity": "sha512-vS54wQjy4IinLSlb5EIlLoln8buh1yDgliP4CuEHumrPk4PvvP4kTRIG4SzMXm6t19N0rIfT4bNdAxzJLg2k6A==",
       "cpu": [
         "mips64el"
       ],
@@ -839,9 +947,9 @@
       }
     },
     "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.20.tgz",
-      "integrity": "sha512-xkYjQtITA6q/b+/5aAf5n2L063pOxLyXUIad+zYT8GpZh0Sa7aSn18BmrFa2fHb0QSGgTEeRfYkTcBGgoPDjBA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.51.tgz",
+      "integrity": "sha512-xcdd62Y3VfGoyphNP/aIV9LP+RzFw5M5Z7ja+zdpQHHvokJM7d0rlDRMN+iSSwvUymQkqZO+G/xjb4/75du8BQ==",
       "cpu": [
         "ppc64"
       ],
@@ -853,10 +961,25 @@
         "node": ">=12"
       }
     },
+    "node_modules/esbuild-linux-riscv64": {
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.51.tgz",
+      "integrity": "sha512-syXHGak9wkAnFz0gMmRBoy44JV0rp4kVCEA36P5MCeZcxFq8+fllBC2t6sKI23w3qd8Vwo9pTADCgjTSf3L3rA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/esbuild-linux-s390x": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.20.tgz",
-      "integrity": "sha512-AAcj3x80TXIedpNVuZgjYNETXr2iciOBQv5pGdNGAy6rv7k6Y6sT6SXQ58l2LH2AHbaeTPQjze+Y6qgX1efzrA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.51.tgz",
+      "integrity": "sha512-kFAJY3dv+Wq8o28K/C7xkZk/X34rgTwhknSsElIqoEo8armCOjMJ6NsMxm48KaWY2h2RUYGtQmr+RGuUPKBhyw==",
       "cpu": [
         "s390x"
       ],
@@ -869,9 +992,9 @@
       }
     },
     "node_modules/esbuild-netbsd-64": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.20.tgz",
-      "integrity": "sha512-30GQKCnsID1WddUi6tr5HFUxJD0t7Uitf6tO9Cf1WqF6C44pf8EflwrhyDFmUyvkddlyfb4OrYI6NNLC/G3ajg==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.51.tgz",
+      "integrity": "sha512-ZZBI7qrR1FevdPBVHz/1GSk1x5GDL/iy42Zy8+neEm/HA7ma+hH/bwPEjeHXKWUDvM36CZpSL/fn1/y9/Hb+1A==",
       "cpu": [
         "x64"
       ],
@@ -884,9 +1007,9 @@
       }
     },
     "node_modules/esbuild-openbsd-64": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.20.tgz",
-      "integrity": "sha512-zVrf8fY46BK57AkxDdqu2S8TV3p7oLmYIiW707IOHrveI0TwJ2iypAxnwOQuCvowM3UWqVBO2RDBzV7S7t0klg==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.51.tgz",
+      "integrity": "sha512-7R1/p39M+LSVQVgDVlcY1KKm6kFKjERSX1lipMG51NPcspJD1tmiZSmmBXoY5jhHIu6JL1QkFDTx94gMYK6vfA==",
       "cpu": [
         "x64"
       ],
@@ -899,9 +1022,9 @@
       }
     },
     "node_modules/esbuild-sunos-64": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.20.tgz",
-      "integrity": "sha512-MYRsS1O7+aBr2T/0aA4OJrju6eMku4rm81fwGF1KLFwmymIpPGmj7n69n5JW3NKyW5j+FBt0GcyDh9nEnUL1FQ==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.51.tgz",
+      "integrity": "sha512-HoHaCswHxLEYN8eBTtyO0bFEWvA3Kdb++hSQ/lLG7TyKF69TeSG0RNoBRAs45x/oCeWaTDntEZlYwAfQlhEtJA==",
       "cpu": [
         "x64"
       ],
@@ -914,9 +1037,9 @@
       }
     },
     "node_modules/esbuild-windows-32": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.20.tgz",
-      "integrity": "sha512-7VqDITqTU65LQ1Uka/4jx4sUIZc1L8NPlvc7HBRdR15TUyPxmHRQaxMGXd8aakI1FEBcImpJ9SQ4JLmPwRlS1w==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.51.tgz",
+      "integrity": "sha512-4rtwSAM35A07CBt1/X8RWieDj3ZUHQqUOaEo5ZBs69rt5WAFjP4aqCIobdqOy4FdhYw1yF8Z0xFBTyc9lgPtEg==",
       "cpu": [
         "ia32"
       ],
@@ -929,9 +1052,9 @@
       }
     },
     "node_modules/esbuild-windows-64": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.20.tgz",
-      "integrity": "sha512-q4GxY4m5+nXSgqCKx6Cc5pavnhd2g5mHn+K8kNdfCMZsWPDlHLMRjYF5NVQ3/5mJ1M7iR3/Ai4ISjxmsCeGOGA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.51.tgz",
+      "integrity": "sha512-HoN/5HGRXJpWODprGCgKbdMvrC3A2gqvzewu2eECRw2sYxOUoh2TV1tS+G7bHNapPGI79woQJGV6pFH7GH7qnA==",
       "cpu": [
         "x64"
       ],
@@ -944,9 +1067,9 @@
       }
     },
     "node_modules/esbuild-windows-arm64": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.20.tgz",
-      "integrity": "sha512-vOxfU7YwuBMjsUNUygMBhC8T60aCzeYptnHu4k7azqqOVo5EAyoueyWSkFR5GpX6bae5cXyB0vcOV/bfwqRwAg==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.51.tgz",
+      "integrity": "sha512-JQDqPjuOH7o+BsKMSddMfmVJXrnYZxXDHsoLHc0xgmAZkOOCflRmC43q31pk79F9xuyWY45jDBPolb5ZgGOf9g==",
       "cpu": [
         "arm64"
       ],
@@ -956,6 +1079,57 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/html-rewriter-wasm": {
@@ -984,6 +1158,44 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/jquery": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
@@ -996,9 +1208,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/kleur": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
-      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
       "engines": {
         "node": ">=6"
       }
@@ -1029,29 +1241,49 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/miniflare": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.4.0.tgz",
-      "integrity": "sha512-xOBL/dQsUL95rxIYO+KrrVPPpm2TAf6TKl4AvhcjSfUeVkzDWd/y9f7hXCt8x6srDoK0Z2LpYouatvSfSUzGOw==",
+    "node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
       "dependencies": {
-        "@miniflare/cache": "2.4.0",
-        "@miniflare/cli-parser": "2.4.0",
-        "@miniflare/core": "2.4.0",
-        "@miniflare/durable-objects": "2.4.0",
-        "@miniflare/html-rewriter": "2.4.0",
-        "@miniflare/http-server": "2.4.0",
-        "@miniflare/kv": "2.4.0",
-        "@miniflare/runner-vm": "2.4.0",
-        "@miniflare/scheduler": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/sites": "2.4.0",
-        "@miniflare/storage-file": "2.4.0",
-        "@miniflare/storage-memory": "2.4.0",
-        "@miniflare/web-sockets": "2.4.0",
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.6.0.tgz",
+      "integrity": "sha512-KDAQZV2aDZ044X1ihlCIa6DPdq1w3fUJFW4xZ+r+DPUxj9t1AuehjR9Fc6zCmZQrk12gLXDSZSyNft1ozm1X7Q==",
+      "dependencies": {
+        "@miniflare/cache": "2.6.0",
+        "@miniflare/cli-parser": "2.6.0",
+        "@miniflare/core": "2.6.0",
+        "@miniflare/durable-objects": "2.6.0",
+        "@miniflare/html-rewriter": "2.6.0",
+        "@miniflare/http-server": "2.6.0",
+        "@miniflare/kv": "2.6.0",
+        "@miniflare/r2": "2.6.0",
+        "@miniflare/runner-vm": "2.6.0",
+        "@miniflare/scheduler": "2.6.0",
+        "@miniflare/shared": "2.6.0",
+        "@miniflare/sites": "2.6.0",
+        "@miniflare/storage-file": "2.6.0",
+        "@miniflare/storage-memory": "2.6.0",
+        "@miniflare/web-sockets": "2.6.0",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
-        "undici": "4.13.0"
+        "undici": "5.5.1"
       },
       "bin": {
         "miniflare": "bootstrap.js"
@@ -1060,7 +1292,7 @@
         "node": ">=16.7"
       },
       "peerDependencies": {
-        "@miniflare/storage-redis": "2.4.0",
+        "@miniflare/storage-redis": "2.6.0",
         "cron-schedule": "^3.0.4",
         "ioredis": "^4.27.9"
       },
@@ -1090,9 +1322,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -1157,6 +1389,14 @@
         "node": ">= 6.13.0"
       }
     },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1165,10 +1405,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/popper.js": {
       "version": "1.16.1",
@@ -1357,6 +1613,17 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
@@ -1375,6 +1642,33 @@
         "replicache": {
           "optional": true
         }
+      }
+    },
+    "node_modules/rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
+      "dependencies": {
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "node_modules/rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "dependencies": {
+        "rollup-plugin-inject": "^3.0.0"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dependencies": {
+        "estree-walker": "^0.6.1"
       }
     },
     "node_modules/scheduler": {
@@ -1406,9 +1700,9 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz",
-      "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
+      "integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ=="
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -1435,20 +1729,25 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+    },
     "node_modules/stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/styled-jsx": {
@@ -1468,6 +1767,17 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/typescript": {
@@ -1497,12 +1807,17 @@
       }
     },
     "node_modules/undici": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-4.13.0.tgz",
-      "integrity": "sha512-8lk8S/f2V0VUNGf2scU2b+KI2JSzEQLdCyRNRF3XmHu+5jectlSDaPSBCXAHFaUlt1rzngzOBVDgJS9/Gue/KA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.5.1.tgz",
+      "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw==",
       "engines": {
         "node": ">=12.18"
       }
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-4.0.3.tgz",
+      "integrity": "sha512-DOE84vZT2fEcl9gqCUTcnAw5ZY5Id55ikUcziSUntuEFL3pRvavg5kwDmTEUJkeCHInTlV/HexFomgYnzO5kdQ=="
     },
     "node_modules/warning": {
       "version": "4.0.3",
@@ -1512,10 +1827,47 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/wrangler": {
+      "version": "2.0.24",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.0.24.tgz",
+      "integrity": "sha512-I43FZzbzSApcgha30E0XEdd5B2dW7BVHFc5SRu/zVLjtY0AwAJctuOz9v5RVKOAjbj8mLvSXCdcZoBCK/7Oi/g==",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "^0.2.0",
+        "@esbuild-plugins/node-globals-polyfill": "^0.1.1",
+        "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
+        "blake3-wasm": "^2.1.5",
+        "chokidar": "^3.5.3",
+        "esbuild": "0.14.51",
+        "miniflare": "^2.6.0",
+        "nanoid": "^3.3.3",
+        "path-to-regexp": "^6.2.0",
+        "selfsigned": "^2.0.1",
+        "source-map": "^0.7.4",
+        "xxhash-wasm": "^1.0.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=16.7.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/wrangler/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/ws": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.6.0.tgz",
-      "integrity": "sha512-AzmM3aH3gk0aX7/rZLYvjdvZooofDu3fFOzGqcSnQ1tOcTWwhM/o+q++E8mAyVVIyUdajrkzWUGftaVSDLn1bw==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1531,6 +1883,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.0.1.tgz",
+      "integrity": "sha512-Lc9CTvDrH2vRoiaUzz25q7lRaviMhz90pkx6YxR9EPYtF99yOJnv2cB+CQ0hp/TLoqrUsk8z/W2EN31T568Azw=="
     },
     "node_modules/youch": {
       "version": "2.2.2",
@@ -1561,10 +1918,18 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@cloudflare/kv-asset-handler": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.2.0.tgz",
+      "integrity": "sha512-MVbXLbTcAotOPUj0pAMhVtJ+3/kFkwJqc5qNOleOZTv6QkZZABDMS21dSrSlVswEHwrpWC03e4fWytjqKvuE2A==",
+      "requires": {
+        "mime": "^3.0.0"
+      }
+    },
     "@cloudflare/workers-types": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.3.1.tgz",
-      "integrity": "sha512-GJFDgWd8ZHlr/m+Q2mp4xUl0/FIPpR6kf0Ix2C78E9HeJyUCW0c0w2EKCvgEDFFKB2rkzIX3eBqZCnLsbsw8zQ=="
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.14.1.tgz",
+      "integrity": "sha512-B1/plF62pt+H2IJHvApK8fdOJAVsvojvacuac8x8s+JIyqbropMyqNqHTKLm3YD8ZFLGwYeFTudU+PQ7vGvBdA=="
     },
     "@datadog/browser-core": {
       "version": "4.11.3",
@@ -1579,161 +1944,186 @@
         "@datadog/browser-core": "4.11.3"
       }
     },
+    "@esbuild-plugins/node-globals-polyfill": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.1.1.tgz",
+      "integrity": "sha512-MR0oAA+mlnJWrt1RQVQ+4VYuRJW/P2YmRTv1AsplObyvuBMnPHiizUF95HHYiSsMGLhyGtWufaq2XQg6+iurBg==",
+      "requires": {}
+    },
+    "@esbuild-plugins/node-modules-polyfill": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.1.4.tgz",
+      "integrity": "sha512-uZbcXi0zbmKC/050p3gJnne5Qdzw8vkXIv+c2BW0Lsc1ji1SkrxbKPUy5Efr0blbTu1SL8w4eyfpnSdPg3G0Qg==",
+      "requires": {
+        "escape-string-regexp": "^4.0.0",
+        "rollup-plugin-node-polyfills": "^0.2.1"
+      }
+    },
     "@iarna/toml": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
     },
     "@miniflare/cache": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.4.0.tgz",
-      "integrity": "sha512-tMDXlUVlThgFubJmlxZoKmLK8kBxDmuMbVMt7csHpXegzkuo2TmIsDqBE/C3CRiJ5xeCQgpD6iZtKBu5Zn5fRA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.6.0.tgz",
+      "integrity": "sha512-4oh8MgpquoxaslI7Z8sMzmEZR0Dc+L3aEh69o9d8ZCs4nUdOENnfKlY50O5nEnL7nhhyAljkMBaXD2wAH2DLeQ==",
       "requires": {
-        "@miniflare/core": "2.4.0",
-        "@miniflare/shared": "2.4.0",
+        "@miniflare/core": "2.6.0",
+        "@miniflare/shared": "2.6.0",
         "http-cache-semantics": "^4.1.0",
-        "undici": "4.13.0"
+        "undici": "5.5.1"
       }
     },
     "@miniflare/cli-parser": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.4.0.tgz",
-      "integrity": "sha512-Xr5lO8f+oIr9r/b2dfo0on1p0MNN+pkwRHWoY5ACSnp9FaGnwm/g71DM7AajIQPIk0TpRsSVNDx8Ygj1LPT+sQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.6.0.tgz",
+      "integrity": "sha512-dJDoIPAUqWhzvBHHyqyhobdzDedBYRWZ4yItBi9m4MTU/EneLJ5jryB340SwUnmtBMZxUh/LWdAuUEkKpdVNyA==",
       "requires": {
-        "@miniflare/shared": "2.4.0",
+        "@miniflare/shared": "2.6.0",
         "kleur": "^4.1.4"
       }
     },
     "@miniflare/core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.4.0.tgz",
-      "integrity": "sha512-vYl8xaWTFzxtkbzx3IkT4Py0OAFdfmFnVo627O1HKHWVGlkjVr8UKtxBpIR+f5pq/HCMzzqA1HM9FXO0dQfy3A==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.6.0.tgz",
+      "integrity": "sha512-CmofhIRot++GI7NHPMwzNb65+0hWLN186L91BrH/doPVHnT/itmEfzYQpL9bFLD0c/i14dfv+IUNetDdGEBIrw==",
       "requires": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/watcher": "2.4.0",
-        "busboy": "^0.3.1",
+        "@miniflare/shared": "2.6.0",
+        "@miniflare/watcher": "2.6.0",
+        "busboy": "^1.6.0",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "4.13.0"
+        "undici": "5.5.1",
+        "urlpattern-polyfill": "^4.0.3"
       }
     },
     "@miniflare/durable-objects": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.4.0.tgz",
-      "integrity": "sha512-VVLaUXXcAQcYE/3YmDLTacZf5OzR8bib6q1T9NqVb0uK5sLMQqyHvQdsG5rMqs7iyxfJxyZ0bL2OW9XGALOkoQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.6.0.tgz",
+      "integrity": "sha512-uzWoGFtkIIh3m3HAzqd5f86nOSC0xFli6dq2q7ilE3UjgouOcLqObxJyE/IzvSwsj4DUWFv6//YDfHihK2fGAA==",
       "requires": {
-        "@miniflare/core": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/storage-memory": "2.4.0",
-        "undici": "4.13.0"
+        "@miniflare/core": "2.6.0",
+        "@miniflare/shared": "2.6.0",
+        "@miniflare/storage-memory": "2.6.0",
+        "undici": "5.5.1"
       }
     },
     "@miniflare/html-rewriter": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.4.0.tgz",
-      "integrity": "sha512-ZG8819N7LelDD+8+Ss5FZpVyQQq/V2igod0qE68JK4he/w4/yn57Rk6Efb49y15HoHAXl2RpCCsnCyIow/Xjug==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.6.0.tgz",
+      "integrity": "sha512-+JqFlIDLzstb/Spj+j/kI6uHzolrqjsMks3Tf24Q4YFo9YYdZguqUFcDz2yr79ZTP/SKXaZH+AYqosnJps4dHQ==",
       "requires": {
-        "@miniflare/core": "2.4.0",
-        "@miniflare/shared": "2.4.0",
+        "@miniflare/core": "2.6.0",
+        "@miniflare/shared": "2.6.0",
         "html-rewriter-wasm": "^0.4.1",
-        "undici": "4.13.0"
+        "undici": "5.5.1"
       }
     },
     "@miniflare/http-server": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.4.0.tgz",
-      "integrity": "sha512-r6Z/nqxE0oa1z63L95yvnG0PUeLRxZOeGS7ADxZMFKan4WD5lvYtSKDuDEm0lkbQshCOHQ3uXFr0cotOm8JoMQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.6.0.tgz",
+      "integrity": "sha512-FhcAVIpipMEzMCsJBc/b0JhNEJ66GPX60vA2NcqjGKHYbwoPCPlwCFQq2giPzW/R95ugrEjPfo4/5Q4UbnpoGA==",
       "requires": {
-        "@miniflare/core": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/web-sockets": "2.4.0",
+        "@miniflare/core": "2.6.0",
+        "@miniflare/shared": "2.6.0",
+        "@miniflare/web-sockets": "2.6.0",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
-        "undici": "4.13.0",
+        "undici": "5.5.1",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       }
     },
     "@miniflare/kv": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.4.0.tgz",
-      "integrity": "sha512-1UW7f1386xR6EDEXNZOR1TpFwQfRRSxUPqD6m/U0WprlsbM0cIYGz+AUeaVbkFf8lfE2MeXCUrjbWsLOvsnw3g==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.6.0.tgz",
+      "integrity": "sha512-7Q+Q0Wwinsz85qpKLlBeXSCLweiVowpMJ5AmQpmELnTya59HQ24cOUHxPd64hXFhdYXVIxOmk6lQaZ21JhdHGQ==",
       "requires": {
-        "@miniflare/shared": "2.4.0"
+        "@miniflare/shared": "2.6.0"
+      }
+    },
+    "@miniflare/r2": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.6.0.tgz",
+      "integrity": "sha512-Ymbqu17ajtuk9b11txF2h1Ewqqlu3XCCpAwAgCQa6AK1yRidQECCPq9w9oXZxE1p5aaSuLTOUbgSdtveFCsLxQ==",
+      "requires": {
+        "@miniflare/shared": "2.6.0",
+        "undici": "5.5.1"
       }
     },
     "@miniflare/runner-vm": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.4.0.tgz",
-      "integrity": "sha512-7sdwBYzXQTwYeR3tTvQ+vJfzc7BXwqR8AUPK9l5gvCtg+Geq9sMslr5SikIJpgcvbYqKDjvC9DQEPJ3sqr9cSQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.6.0.tgz",
+      "integrity": "sha512-ZxsiVMMUcjb01LwrO2t50YbU5PT5s3k7DrmR5185R/n04K5BikqZz8eQf8lKlQQYem0BROqmmQgurZGw0a2HUw==",
       "requires": {
-        "@miniflare/shared": "2.4.0"
+        "@miniflare/shared": "2.6.0"
       }
     },
     "@miniflare/scheduler": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.4.0.tgz",
-      "integrity": "sha512-dfMCXoAS8Y+3xABNxYju62I2xIBS54Op7ohCHoatvAM5RvualJUPICEMPZzX6/z29q5xPIeSLhLDhl/asAQ19w==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.6.0.tgz",
+      "integrity": "sha512-BM+RDF+8twkTCOb7Oz0NIs5phzAVJ/Gx7tFZR23fGsZjWRnE3TBeqfzaNutU9pcoWDZtBQqEJMeTeb0KZTo75Q==",
       "requires": {
-        "@miniflare/core": "2.4.0",
-        "@miniflare/shared": "2.4.0",
+        "@miniflare/core": "2.6.0",
+        "@miniflare/shared": "2.6.0",
         "cron-schedule": "^3.0.4"
       }
     },
     "@miniflare/shared": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.4.0.tgz",
-      "integrity": "sha512-lPQFzBUVGNQ93gQ/dliToWnO0OqAgsD3/902Pd/IixVSRwRj3BTnYv2dHMUKZcODBPrhnbqZeqcPWdBLzEx8uw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.6.0.tgz",
+      "integrity": "sha512-/7k4C37GF0INu99LNFmFhHYL6U9/oRY/nWDa5sr6+lPEKKm2rkmfvDIA+YNAj7Ql61ZWMgEMj0S3NhV0rWkj7Q==",
       "requires": {
         "ignore": "^5.1.8",
         "kleur": "^4.1.4"
       }
     },
     "@miniflare/sites": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.4.0.tgz",
-      "integrity": "sha512-YZy/TujnR1lkBvCncDDQ8tsWsXRE4JJ4x9a0bKN/XnZh7r6OhDM0sw4BFcBQhT6Ukdtttam1O3FlJxnMitrDGg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.6.0.tgz",
+      "integrity": "sha512-XfWhpREC638LOGNmuHaPn1MAz1sh2mz+VdMsjRCzUo6NwPl4IcUhnorJR62Xr0qmI/RqVMTZbvzrChXio4Bi4A==",
       "requires": {
-        "@miniflare/kv": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/storage-file": "2.4.0"
+        "@miniflare/kv": "2.6.0",
+        "@miniflare/shared": "2.6.0",
+        "@miniflare/storage-file": "2.6.0"
       }
     },
     "@miniflare/storage-file": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.4.0.tgz",
-      "integrity": "sha512-f1AUMz8xps/4VhNJMb8JeCevZFeU4pg2lIWmC11gG4xeq2nibTPBi6Qtx594Le7ZKij/tF6rRsoNfGau2Q5gdw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.6.0.tgz",
+      "integrity": "sha512-xprDVJClQ2X1vXVPM16WQZz3rS+6fNuCYC8bfEFHABDByQoUNDpk8q+m1IpTaFXYivYxRhE+xr7eK2QQP068tA==",
       "requires": {
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/storage-memory": "2.4.0"
+        "@miniflare/shared": "2.6.0",
+        "@miniflare/storage-memory": "2.6.0"
       }
     },
     "@miniflare/storage-memory": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.4.0.tgz",
-      "integrity": "sha512-mhWwgHhDNtEa7y1bYbdVucV0lqUmzagYXUSppAdSGS5JPyJMyw3HseqRNTk6gC/vKlvEYlFf3ugWcREGCedr9A==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.6.0.tgz",
+      "integrity": "sha512-0EwELTG2r6IC4AMlQv0YXRZdw9g/lCydceuGKeFkWAVb55pY+yMBxkJO9VV7QOrEx8MLsR8tsfl5SBK3AkfLtA==",
       "requires": {
-        "@miniflare/shared": "2.4.0"
+        "@miniflare/shared": "2.6.0"
       }
     },
     "@miniflare/watcher": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.4.0.tgz",
-      "integrity": "sha512-gDQRUxwOjmctvowyd4Hcdy3fjxz3ERKzirp6TvA3AWUohKZk3IhwGlaA8aCwbdP+ELYQlG5wK44AfLSGi956fg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.6.0.tgz",
+      "integrity": "sha512-mttfhNDmEIFo2rWF73JeWj1TLN+3cQC1TFhbtLApz9bXilLywArXMYqDJGA8PUnJCFM/8k2FDjaFNiPy6ggIJw==",
       "requires": {
-        "@miniflare/shared": "2.4.0"
+        "@miniflare/shared": "2.6.0"
       }
     },
     "@miniflare/web-sockets": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.4.0.tgz",
-      "integrity": "sha512-cz/cN0GoQOXRLh80UmlcEJODPIw2ijKBK3PLRzvfTzqQ5avK6wp2M8Fj8C/5JIT6g7siwvBANyKXD3U3RpKGHQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.6.0.tgz",
+      "integrity": "sha512-ePbcuP9LrStVTllZzqx2oNVoOpceyU3jJF3nGDMNW5+bqB+BdeTggSF8rhER7omcSCswCMY2Do6VelIcAXHkXA==",
       "requires": {
-        "@miniflare/core": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "undici": "4.13.0",
+        "@miniflare/core": "2.6.0",
+        "@miniflare/shared": "2.6.0",
+        "undici": "5.5.1",
         "ws": "^8.2.2"
       }
     },
@@ -1904,11 +2294,38 @@
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
       "integrity": "sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI="
     },
+    "anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+    },
+    "blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="
+    },
     "bootstrap": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
       "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==",
       "requires": {}
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
     },
     "buffer-from": {
       "version": "1.1.2",
@@ -1916,17 +2333,32 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "busboy": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
-      "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
       "requires": {
-        "dicer": "0.3.0"
+        "streamsearch": "^1.1.0"
       }
     },
     "caniuse-lite": {
       "version": "1.0.30001343",
       "resolved": "https://registry.npmmirror.com/caniuse-lite/-/caniuse-lite-1.0.30001343.tgz",
       "integrity": "sha512-8KeCrAtPMabo/XW14B+R9sZYoClx1n0b+WYgwDKZPtWR3TcdvWzdSy7mPyFEmR5WU1St9v1PW6sdO5dkFOEzfA=="
+    },
+    "chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      }
     },
     "classnames": {
       "version": "2.3.1",
@@ -1958,14 +2390,6 @@
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
       "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
     },
-    "dicer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
-      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
-      "requires": {
-        "streamsearch": "0.1.2"
-      }
-    },
     "dom-helpers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
@@ -1981,137 +2405,183 @@
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
     },
     "esbuild": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.20.tgz",
-      "integrity": "sha512-7aRJRnTjHZ6rFEre52tsAYZxatVELSA/QvYGUBf1iOsYKCnSJICE5seugQFFJgV1Gyl0/mngxQPhxBIqgYG2BA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.51.tgz",
+      "integrity": "sha512-+CvnDitD7Q5sT7F+FM65sWkF8wJRf+j9fPcprxYV4j+ohmzVj2W7caUqH2s5kCaCJAfcAICjSlKhDCcvDpU7nw==",
       "requires": {
-        "esbuild-android-arm64": "0.14.20",
-        "esbuild-darwin-64": "0.14.20",
-        "esbuild-darwin-arm64": "0.14.20",
-        "esbuild-freebsd-64": "0.14.20",
-        "esbuild-freebsd-arm64": "0.14.20",
-        "esbuild-linux-32": "0.14.20",
-        "esbuild-linux-64": "0.14.20",
-        "esbuild-linux-arm": "0.14.20",
-        "esbuild-linux-arm64": "0.14.20",
-        "esbuild-linux-mips64le": "0.14.20",
-        "esbuild-linux-ppc64le": "0.14.20",
-        "esbuild-linux-s390x": "0.14.20",
-        "esbuild-netbsd-64": "0.14.20",
-        "esbuild-openbsd-64": "0.14.20",
-        "esbuild-sunos-64": "0.14.20",
-        "esbuild-windows-32": "0.14.20",
-        "esbuild-windows-64": "0.14.20",
-        "esbuild-windows-arm64": "0.14.20"
+        "esbuild-android-64": "0.14.51",
+        "esbuild-android-arm64": "0.14.51",
+        "esbuild-darwin-64": "0.14.51",
+        "esbuild-darwin-arm64": "0.14.51",
+        "esbuild-freebsd-64": "0.14.51",
+        "esbuild-freebsd-arm64": "0.14.51",
+        "esbuild-linux-32": "0.14.51",
+        "esbuild-linux-64": "0.14.51",
+        "esbuild-linux-arm": "0.14.51",
+        "esbuild-linux-arm64": "0.14.51",
+        "esbuild-linux-mips64le": "0.14.51",
+        "esbuild-linux-ppc64le": "0.14.51",
+        "esbuild-linux-riscv64": "0.14.51",
+        "esbuild-linux-s390x": "0.14.51",
+        "esbuild-netbsd-64": "0.14.51",
+        "esbuild-openbsd-64": "0.14.51",
+        "esbuild-sunos-64": "0.14.51",
+        "esbuild-windows-32": "0.14.51",
+        "esbuild-windows-64": "0.14.51",
+        "esbuild-windows-arm64": "0.14.51"
       }
     },
+    "esbuild-android-64": {
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.51.tgz",
+      "integrity": "sha512-6FOuKTHnC86dtrKDmdSj2CkcKF8PnqkaIXqvgydqfJmqBazCPdw+relrMlhGjkvVdiiGV70rpdnyFmA65ekBCQ==",
+      "optional": true
+    },
     "esbuild-android-arm64": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.20.tgz",
-      "integrity": "sha512-MPKVDe3TMjGDRB5WmY9XnBaXEsPiiTpkz6GjXgBhBkMFZm27PhvZT4JE0vZ1fsLb5hnGC/fYsfAnp9rsxTZhIg==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.51.tgz",
+      "integrity": "sha512-vBtp//5VVkZWmYYvHsqBRCMMi1MzKuMIn5XDScmnykMTu9+TD9v0NMEDqQxvtFToeYmojdo5UCV2vzMQWJcJ4A==",
       "optional": true
     },
     "esbuild-darwin-64": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.20.tgz",
-      "integrity": "sha512-09PPWejM3rRFsGHvtaTuRlG+KOQlOMwPW4HwwzRlO4TuP+FNV1nTW4x2Nid3dYLzCkcjznJWQ0oylLBQvGTRyQ==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.51.tgz",
+      "integrity": "sha512-YFmXPIOvuagDcwCejMRtCDjgPfnDu+bNeh5FU2Ryi68ADDVlWEpbtpAbrtf/lvFTWPexbgyKgzppNgsmLPr8PA==",
       "optional": true
     },
     "esbuild-darwin-arm64": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.20.tgz",
-      "integrity": "sha512-jYLrSXAwygoFF2lpRJSUAghre+9IThbcPvJQbcZMONBQaaZft9nclNsrN3k4u7zQaC8v+xZDVSHkmw593tQvkg==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.51.tgz",
+      "integrity": "sha512-juYD0QnSKwAMfzwKdIF6YbueXzS6N7y4GXPDeDkApz/1RzlT42mvX9jgNmyOlWKN7YzQAYbcUEJmZJYQGdf2ow==",
       "optional": true
     },
     "esbuild-freebsd-64": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.20.tgz",
-      "integrity": "sha512-XShznPLW3QsK8/7iCx1euZTowWaWlcrlkq4YTlRqDKXkJRe98FJ6+V2QyoSTwwCoo5koaYwc+h/SYdglF5369A==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.51.tgz",
+      "integrity": "sha512-cLEI/aXjb6vo5O2Y8rvVSQ7smgLldwYY5xMxqh/dQGfWO+R1NJOFsiax3IS4Ng300SVp7Gz3czxT6d6qf2cw0g==",
       "optional": true
     },
     "esbuild-freebsd-arm64": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.20.tgz",
-      "integrity": "sha512-flb3tDd6SScKhBqzWAESVCErpaqrGmMSRrssjx1aC+Ai5ZQrEyhfs5OWL4A9qHuixkhfmXffci7rFD+bNeXmZg==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.51.tgz",
+      "integrity": "sha512-TcWVw/rCL2F+jUgRkgLa3qltd5gzKjIMGhkVybkjk6PJadYInPtgtUBp1/hG+mxyigaT7ib+od1Xb84b+L+1Mg==",
       "optional": true
     },
     "esbuild-linux-32": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.20.tgz",
-      "integrity": "sha512-Avtxbd0MHFJ2QhNxj/e8VGGm1/VnEJZq9qiHUl3wQZ4S0o2Wf4ReAfhqmgAbOPFTuxuZm070rRDZYiZifWzFGQ==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.51.tgz",
+      "integrity": "sha512-RFqpyC5ChyWrjx8Xj2K0EC1aN0A37H6OJfmUXIASEqJoHcntuV3j2Efr9RNmUhMfNE6yEj2VpYuDteZLGDMr0w==",
       "optional": true
     },
     "esbuild-linux-64": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.20.tgz",
-      "integrity": "sha512-ugisoRA/ajCr9JMszsQnT9hKkpbD7Gr1yl1mWdZhWQnGt6JKGIndGiihMURcrR44IK/2OMkixVe66D4gCHKdPA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.51.tgz",
+      "integrity": "sha512-dxjhrqo5i7Rq6DXwz5v+MEHVs9VNFItJmHBe1CxROWNf4miOGoQhqSG8StStbDkQ1Mtobg6ng+4fwByOhoQoeA==",
       "optional": true
     },
     "esbuild-linux-arm": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.20.tgz",
-      "integrity": "sha512-uo++Mo31+P2EA38oQgOeSIWgD7GMCMpZkaLfsCqtKJTIIL9fVzQHQYLDRIiFGpLHvs1faWWHDCEcXEFSP1Ou0g==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.51.tgz",
+      "integrity": "sha512-LsJynDxYF6Neg7ZC7748yweCDD+N8ByCv22/7IAZglIEniEkqdF4HCaa49JNDLw1UQGlYuhOB8ZT/MmcSWzcWg==",
       "optional": true
     },
     "esbuild-linux-arm64": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.20.tgz",
-      "integrity": "sha512-hsrMbNzhh+ud3zUyhONlR41vpYMjINS7BHEzXHbzo4YiCsG9Ht3arbiSuNGrhR/ybLr+8J/0fYVCipiVeAjy3Q==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.51.tgz",
+      "integrity": "sha512-D9rFxGutoqQX3xJPxqd6o+kvYKeIbM0ifW2y0bgKk5HPgQQOo2k9/2Vpto3ybGYaFPCE5qTGtqQta9PoP6ZEzw==",
       "optional": true
     },
     "esbuild-linux-mips64le": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.20.tgz",
-      "integrity": "sha512-MBUu2Q+pzdTBWclPe7AwmRUMTUL0R99ONa8Hswpb987fXgFUdN4XBNBcEa5zy/l2UrIJK+9FUN1jjedZlxgP2A==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.51.tgz",
+      "integrity": "sha512-vS54wQjy4IinLSlb5EIlLoln8buh1yDgliP4CuEHumrPk4PvvP4kTRIG4SzMXm6t19N0rIfT4bNdAxzJLg2k6A==",
       "optional": true
     },
     "esbuild-linux-ppc64le": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.20.tgz",
-      "integrity": "sha512-xkYjQtITA6q/b+/5aAf5n2L063pOxLyXUIad+zYT8GpZh0Sa7aSn18BmrFa2fHb0QSGgTEeRfYkTcBGgoPDjBA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.51.tgz",
+      "integrity": "sha512-xcdd62Y3VfGoyphNP/aIV9LP+RzFw5M5Z7ja+zdpQHHvokJM7d0rlDRMN+iSSwvUymQkqZO+G/xjb4/75du8BQ==",
+      "optional": true
+    },
+    "esbuild-linux-riscv64": {
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.51.tgz",
+      "integrity": "sha512-syXHGak9wkAnFz0gMmRBoy44JV0rp4kVCEA36P5MCeZcxFq8+fllBC2t6sKI23w3qd8Vwo9pTADCgjTSf3L3rA==",
       "optional": true
     },
     "esbuild-linux-s390x": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.20.tgz",
-      "integrity": "sha512-AAcj3x80TXIedpNVuZgjYNETXr2iciOBQv5pGdNGAy6rv7k6Y6sT6SXQ58l2LH2AHbaeTPQjze+Y6qgX1efzrA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.51.tgz",
+      "integrity": "sha512-kFAJY3dv+Wq8o28K/C7xkZk/X34rgTwhknSsElIqoEo8armCOjMJ6NsMxm48KaWY2h2RUYGtQmr+RGuUPKBhyw==",
       "optional": true
     },
     "esbuild-netbsd-64": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.20.tgz",
-      "integrity": "sha512-30GQKCnsID1WddUi6tr5HFUxJD0t7Uitf6tO9Cf1WqF6C44pf8EflwrhyDFmUyvkddlyfb4OrYI6NNLC/G3ajg==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.51.tgz",
+      "integrity": "sha512-ZZBI7qrR1FevdPBVHz/1GSk1x5GDL/iy42Zy8+neEm/HA7ma+hH/bwPEjeHXKWUDvM36CZpSL/fn1/y9/Hb+1A==",
       "optional": true
     },
     "esbuild-openbsd-64": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.20.tgz",
-      "integrity": "sha512-zVrf8fY46BK57AkxDdqu2S8TV3p7oLmYIiW707IOHrveI0TwJ2iypAxnwOQuCvowM3UWqVBO2RDBzV7S7t0klg==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.51.tgz",
+      "integrity": "sha512-7R1/p39M+LSVQVgDVlcY1KKm6kFKjERSX1lipMG51NPcspJD1tmiZSmmBXoY5jhHIu6JL1QkFDTx94gMYK6vfA==",
       "optional": true
     },
     "esbuild-sunos-64": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.20.tgz",
-      "integrity": "sha512-MYRsS1O7+aBr2T/0aA4OJrju6eMku4rm81fwGF1KLFwmymIpPGmj7n69n5JW3NKyW5j+FBt0GcyDh9nEnUL1FQ==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.51.tgz",
+      "integrity": "sha512-HoHaCswHxLEYN8eBTtyO0bFEWvA3Kdb++hSQ/lLG7TyKF69TeSG0RNoBRAs45x/oCeWaTDntEZlYwAfQlhEtJA==",
       "optional": true
     },
     "esbuild-windows-32": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.20.tgz",
-      "integrity": "sha512-7VqDITqTU65LQ1Uka/4jx4sUIZc1L8NPlvc7HBRdR15TUyPxmHRQaxMGXd8aakI1FEBcImpJ9SQ4JLmPwRlS1w==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.51.tgz",
+      "integrity": "sha512-4rtwSAM35A07CBt1/X8RWieDj3ZUHQqUOaEo5ZBs69rt5WAFjP4aqCIobdqOy4FdhYw1yF8Z0xFBTyc9lgPtEg==",
       "optional": true
     },
     "esbuild-windows-64": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.20.tgz",
-      "integrity": "sha512-q4GxY4m5+nXSgqCKx6Cc5pavnhd2g5mHn+K8kNdfCMZsWPDlHLMRjYF5NVQ3/5mJ1M7iR3/Ai4ISjxmsCeGOGA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.51.tgz",
+      "integrity": "sha512-HoN/5HGRXJpWODprGCgKbdMvrC3A2gqvzewu2eECRw2sYxOUoh2TV1tS+G7bHNapPGI79woQJGV6pFH7GH7qnA==",
       "optional": true
     },
     "esbuild-windows-arm64": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.20.tgz",
-      "integrity": "sha512-vOxfU7YwuBMjsUNUygMBhC8T60aCzeYptnHu4k7azqqOVo5EAyoueyWSkFR5GpX6bae5cXyB0vcOV/bfwqRwAg==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.51.tgz",
+      "integrity": "sha512-JQDqPjuOH7o+BsKMSddMfmVJXrnYZxXDHsoLHc0xgmAZkOOCflRmC43q31pk79F9xuyWY45jDBPolb5ZgGOf9g==",
       "optional": true
+    },
+    "escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+    },
+    "estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "optional": true
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
     },
     "html-rewriter-wasm": {
       "version": "0.4.1",
@@ -2136,6 +2606,32 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+    },
     "jquery": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
@@ -2148,9 +2644,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "kleur": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
-      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA=="
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="
     },
     "lodash.isboolean": {
       "version": "3.0.3",
@@ -2175,29 +2671,43 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "miniflare": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.4.0.tgz",
-      "integrity": "sha512-xOBL/dQsUL95rxIYO+KrrVPPpm2TAf6TKl4AvhcjSfUeVkzDWd/y9f7hXCt8x6srDoK0Z2LpYouatvSfSUzGOw==",
+    "magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
       "requires": {
-        "@miniflare/cache": "2.4.0",
-        "@miniflare/cli-parser": "2.4.0",
-        "@miniflare/core": "2.4.0",
-        "@miniflare/durable-objects": "2.4.0",
-        "@miniflare/html-rewriter": "2.4.0",
-        "@miniflare/http-server": "2.4.0",
-        "@miniflare/kv": "2.4.0",
-        "@miniflare/runner-vm": "2.4.0",
-        "@miniflare/scheduler": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/sites": "2.4.0",
-        "@miniflare/storage-file": "2.4.0",
-        "@miniflare/storage-memory": "2.4.0",
-        "@miniflare/web-sockets": "2.4.0",
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="
+    },
+    "miniflare": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.6.0.tgz",
+      "integrity": "sha512-KDAQZV2aDZ044X1ihlCIa6DPdq1w3fUJFW4xZ+r+DPUxj9t1AuehjR9Fc6zCmZQrk12gLXDSZSyNft1ozm1X7Q==",
+      "requires": {
+        "@miniflare/cache": "2.6.0",
+        "@miniflare/cli-parser": "2.6.0",
+        "@miniflare/core": "2.6.0",
+        "@miniflare/durable-objects": "2.6.0",
+        "@miniflare/html-rewriter": "2.6.0",
+        "@miniflare/http-server": "2.6.0",
+        "@miniflare/kv": "2.6.0",
+        "@miniflare/r2": "2.6.0",
+        "@miniflare/runner-vm": "2.6.0",
+        "@miniflare/scheduler": "2.6.0",
+        "@miniflare/shared": "2.6.0",
+        "@miniflare/sites": "2.6.0",
+        "@miniflare/storage-file": "2.6.0",
+        "@miniflare/storage-memory": "2.6.0",
+        "@miniflare/web-sockets": "2.6.0",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
-        "undici": "4.13.0"
+        "undici": "5.5.1"
       }
     },
     "mousetrap": {
@@ -2211,9 +2721,9 @@
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="
     },
     "nanoid": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA=="
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
     },
     "next": {
       "version": "12.1.6",
@@ -2243,15 +2753,30 @@
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
     },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
+    "path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
+    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "popper.js": {
       "version": "1.16.1",
@@ -2393,6 +2918,14 @@
         "prop-types": "^15.6.2"
       }
     },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
@@ -2403,6 +2936,32 @@
       "resolved": "https://registry.npmjs.org/replicache-react/-/replicache-react-2.6.0.tgz",
       "integrity": "sha512-WT2PvefG+prPLj+pPMdYY6sFwOjPf0JRrsE00Mx42d3uF8ARpKNO6N0Tm07yEpg78f5Xm2JzksM6BUb/n4Z13g==",
       "requires": {}
+    },
+    "rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "requires": {
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "requires": {
+        "rollup-plugin-inject": "^3.0.0"
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "requires": {
+        "estree-walker": "^0.6.1"
+      }
     },
     "scheduler": {
       "version": "0.20.2",
@@ -2427,9 +2986,9 @@
       "integrity": "sha512-QNI2ChmuioGC1/xjyYwyZYADILWyW6AmS1UH6gDj/SFUUUS4MBAWs/7mxnkRPc/F4iHezDP+O8t0dO8WHiEOdg=="
     },
     "set-cookie-parser": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz",
-      "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
+      "integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ=="
     },
     "source-map": {
       "version": "0.6.1",
@@ -2450,21 +3009,34 @@
         "source-map": "^0.6.0"
       }
     },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+    },
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="
     },
     "streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
     },
     "styled-jsx": {
       "version": "5.0.2",
       "resolved": "https://registry.npmmirror.com/styled-jsx/-/styled-jsx-5.0.2.tgz",
       "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==",
       "requires": {}
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "requires": {
+        "is-number": "^7.0.0"
+      }
     },
     "typescript": {
       "version": "4.5.5",
@@ -2483,9 +3055,14 @@
       }
     },
     "undici": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-4.13.0.tgz",
-      "integrity": "sha512-8lk8S/f2V0VUNGf2scU2b+KI2JSzEQLdCyRNRF3XmHu+5jectlSDaPSBCXAHFaUlt1rzngzOBVDgJS9/Gue/KA=="
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.5.1.tgz",
+      "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw=="
+    },
+    "urlpattern-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-4.0.3.tgz",
+      "integrity": "sha512-DOE84vZT2fEcl9gqCUTcnAw5ZY5Id55ikUcziSUntuEFL3pRvavg5kwDmTEUJkeCHInTlV/HexFomgYnzO5kdQ=="
     },
     "warning": {
       "version": "4.0.3",
@@ -2495,11 +3072,43 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "wrangler": {
+      "version": "2.0.24",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.0.24.tgz",
+      "integrity": "sha512-I43FZzbzSApcgha30E0XEdd5B2dW7BVHFc5SRu/zVLjtY0AwAJctuOz9v5RVKOAjbj8mLvSXCdcZoBCK/7Oi/g==",
+      "requires": {
+        "@cloudflare/kv-asset-handler": "^0.2.0",
+        "@esbuild-plugins/node-globals-polyfill": "^0.1.1",
+        "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
+        "blake3-wasm": "^2.1.5",
+        "chokidar": "^3.5.3",
+        "esbuild": "0.14.51",
+        "fsevents": "~2.3.2",
+        "miniflare": "^2.6.0",
+        "nanoid": "^3.3.3",
+        "path-to-regexp": "^6.2.0",
+        "selfsigned": "^2.0.1",
+        "source-map": "^0.7.4",
+        "xxhash-wasm": "^1.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+          "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA=="
+        }
+      }
+    },
     "ws": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.6.0.tgz",
-      "integrity": "sha512-AzmM3aH3gk0aX7/rZLYvjdvZooofDu3fFOzGqcSnQ1tOcTWwhM/o+q++E8mAyVVIyUdajrkzWUGftaVSDLn1bw==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
       "requires": {}
+    },
+    "xxhash-wasm": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.0.1.tgz",
+      "integrity": "sha512-Lc9CTvDrH2vRoiaUzz25q7lRaviMhz90pkx6YxR9EPYtF99yOJnv2cB+CQ0hp/TLoqrUsk8z/W2EN31T568Azw=="
     },
     "youch": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -4,15 +4,14 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev-worker": "miniflare --debug",
-    "build-worker": "esbuild --bundle --format=esm --outfile=dist/index.mjs --tsconfig=worker/tsconfig.json worker/index.ts ",
+    "dev-worker": "wrangler dev --local --experimental-enable-local-persistence",
     "build": "rm -rf dist && next build && npm run build-worker",
     "start": "next start",
     "format": "prettier --write './**/*.{js,jsx,json,ts,tsx,html,css,md}'",
     "check-types": "tsc -p tsconfig.json --noEmit && tsc -p worker/tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@cloudflare/workers-types": "^3.3.1",
+    "@cloudflare/workers-types": "^3.11.0",
     "@rocicorp/reflect": "^0.6.0",
     "@datadog/browser-logs": "^4.11.3",
     "@rocicorp/logger": "^2.2.0",
@@ -21,8 +20,6 @@
     "@types/react": "^17.0.39",
     "@types/react-dom": "^17.0.11",
     "bootstrap": "^4.6.0",
-    "esbuild": "^0.14.20",
-    "miniflare": "^2.3.0",
     "nanoid": "^3.2.0",
     "next": "^12.1.6",
     "prettier": "^2.5.1",
@@ -33,6 +30,7 @@
     "react-hotkeys": "^1.1.4",
     "replicache-react": "^2.6.0",
     "typescript": "^4.5.5",
+    "wrangler": "^2.0.7",
     "zod": "^3.11.6"
   }
 }

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -16,13 +16,13 @@
     "noFallthroughCasesInSwitch": true,
     "importsNotUsedAsValues": "error",
     "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
 
     "declaration": true,
     "allowJs": true,
 
     "incremental": true,
-    "outDir": "../dist",
-    "baseUrl": "."
+    "noEmit": true
   },
   "include": ["**/*.ts"],
   "exclude": ["dist", "node_modules", "out"]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,13 +1,7 @@
 name = "replidraw"
-type = "javascript"
+main = "worker/index.ts"
+compatibility_date = "2022-06-03"
 
-account_id = "085f6d8eb08e5b23debfb08b21bda1eb"
-workers_dev = true
-# route = ""
-# zone_id = ""
-
-compatibility_date = "2022-02-10"
-compatibility_flags = []
 
 [durable_objects]
 bindings = [
@@ -26,17 +20,6 @@ new_classes = ["AuthDO"]
 
 [triggers]
 crons = [ "*/5 * * * *" ] # ever 5 mins for AuthDO connection revalidation
-
-[build]
-command = "npm run build-worker"
-
-[build.upload]
-format = "modules"
-dir = "dist"
-main = "./index.mjs"
-
-[miniflare]
-durable_objects_persist = true
 
 #[secrets]
 #DATADOG_API_KEY


### PR DESCRIPTION
This PR updates `wrangler` to 2.x. This includes a simpler `wrangler.toml`, but with the same functionality/expectations as it already was, including the local simulation environment.

--- 

Feel free to give this a spin before landing it! Happy to get some feedback and make sure you're happy with it before it's merged.

After this, I'll probably work on some additional enhancements - 

- This setup gave me an idea for how we should integrate with nextjs a little better, tracking it here https://github.com/cloudflare/wrangler2/issues/1180. Doing that should make dev a single command, and also enable you to deploy the entire worker+assets directly to cloudflare. 
- I'm going to investigate needing `# Must have published at least once prior` for running `wrangler dev`, looks like the websockets don't work correctly until the first publish? That sounds like a bug with `wrangler dev`, I'll look into it. 
- I'll try to think of a better solution for https://github.com/rocicorp/replidraw-do/blob/feca0378b0f97ebf79057edd3f6642f431c29eb9/src/pages/d/%5Bid%5D.tsx#L16-L17, we shouldn't have to hardcode the host there. 