### PR TITLE
fix: correct data dog logging service name

### DIFF
--- a/worker/index.ts
+++ b/worker/index.ts
@@ -14,7 +14,7 @@ function getLogSinks(env: ReplidrawEnv): LogSink[] {
     logSinks.push(
       new DatadogLogSink({
         apiKey: env.DATADOG_API_KEY,
-        service: "replidraw-do-grgbkr",
+        service: "replidraw-do",
       })
     );
   }


### PR DESCRIPTION
Correct data dog logging service name from "replidraw-do-grgbkr" to "replidraw-do".